### PR TITLE
Feat/9 Password 노출 방지 및 방향키 지원

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 CFLAGS = -Wall -Wextra -std=c11 -I/usr/include/x86_64-linux-gnu
 LDFLAGS = -L/usr/lib/x86_64-linux-gnu
-LIBS = -lssl -lcrypto
+LIBS = -lssl -lcrypto -lreadline
 
 # 디렉토리
 SRC_COMMON = src/common


### PR DESCRIPTION
## 연관된 이슈

> Closes: #9 

## 작업 상세

- register, login 시 터미널에 노출되는 비밀번호 TTY 사용으로 echo 없이 입력
- CLI 입력을 GNU `readline` 기반으로 변경해 방향키/히스토리 등 지원